### PR TITLE
Deprecated mod_fastcgi

### DIFF
--- a/conf.d/php-fpm.conf
+++ b/conf.d/php-fpm.conf
@@ -1,38 +1,9 @@
 
-# Load PHP-FPM via mod_fastcgi
-LoadModule fastcgi_module /usr/local/opt/mod_fastcgi/libexec/mod_fastcgi.so
-
-<IfModule fastcgi_module>
-  FastCgiConfig -maxClassProcesses 1 -idle-timeout 1500
-  # Prevent accessing FastCGI alias paths directly
-  <LocationMatch "^/fastcgi">
-    <IfModule mod_authz_core.c>
-      Require env REDIRECT_STATUS
-    </IfModule>
-    <IfModule !mod_authz_core.c>
-      Order Deny,Allow
-      Deny from All
-      Allow from env=REDIRECT_STATUS
-    </IfModule>
-  </LocationMatch>
-  
-  FastCgiExternalServer /php-fpm -host 127.0.0.1:9000 -pass-header Authorization -idle-timeout 1500
-  ScriptAlias /fastcgiphp /php-fpm
-  Action php-fastcgi /fastcgiphp
-  
-  # Send PHP extensions to PHP-FPM
-  <FilesMatch "\.php$">
-    AddHandler php-fastcgi .php
-  </FilesMatch>
-  
-  
-  # PHP options
-  AddType text/html .php
-  AddType application/x-httpd-php .php
-  DirectoryIndex index.php index.html
-  
-  # Set the environment.
-  #SetEnv APP_ENV "dev"
-
-
-</IfModule>
+# Load PHP-FPM via fcgi
+LoadModule proxy_module lib/httpd/modules/mod_proxy.so
+LoadModule proxy_fcgi_module lib/httpd/modules/mod_proxy_fcgi.so
+ 
+# Forward all PHP to PHP-FPM
+<FilesMatch \.php$>
+  SetHandler proxy:fcgi://localhost:9000
+</FilesMatch>


### PR DESCRIPTION
Brew has removed support for mod_fastcgi (see http://formulae.brew.sh/formula/mod_fastcgi).
As of Apache 2.4 we can use proxy_fcgi_module.