### PR TITLE
Consistency in webdev partition lower case.

### DIFF
--- a/documentation/Installation/Apache.md
+++ b/documentation/Installation/Apache.md
@@ -8,17 +8,17 @@ as our web root.
 Create a www folder on the new partition:
 
 ```bash
-mkdir -p /Volumes/Webdev/www
+mkdir -p /Volumes/webdev/www
 ```
 
 Clone the folder structure, configuration & scripts from GitHub in the new 
 directory:
 
 ```bash
-git clone https://github.com/zero2one/HAMmP.git /Volumes/Webdev/www/_apache
+git clone https://github.com/zero2one/HAMmP.git /Volumes/webdev/www/_apache
 ```
 
-You should now have a directory called /Volumes/Webdev/www/_apache
+You should now have a directory called /Volumes/webdev/www/_apache
 
 > **Note** : Cloning the default folder structure, configuration & scripts to 
 > the proper location is very important for the rest of the installation 
@@ -49,7 +49,7 @@ _Multiline command, copy all at once:_
 cat >> ~/.bash_profile <<EOF
 
 # HAMmP -----------------------------------------------
-PATH="/Volumes/Webdev/www/_apache/bin:$PATH"
+PATH="/Volumes/webdev/www/_apache/bin:$PATH"
 
 EOF
 ```
@@ -63,7 +63,7 @@ source ~/.bash_profile
 Make sure that the scripts can be executed:
 
 ```bash
-$ chmod +x /Volumes/Webdev/www/_apache/bin/*
+$ chmod +x /Volumes/webdev/www/_apache/bin/*
 ```
 
 ##	Disable build-in Apache

--- a/documentation/Installation/Homebrew.md
+++ b/documentation/Installation/Homebrew.md
@@ -23,7 +23,7 @@ brew install wget
 pkg-config is required to install some PHP extensions. Install it up-front:
 
 ```bash
-homebrew install pkg-config
+brew install pkg-config
 ```
 
 ## Update GIT to latest version

--- a/documentation/Installation/PHP.md
+++ b/documentation/Installation/PHP.md
@@ -105,7 +105,7 @@ to serve PHP scripts using PHP-FPM. We only need to start the PHP-FPM service:
 brew services start php@5.6
 ```
 
-The config is located at `/Volumes/Webdev/www/_apache/conf.d/php-fpm.conf`.
+The config is located at `/Volumes/webdev/www/_apache/conf.d/php-fpm.conf`.
 
 ## Test
 
@@ -116,7 +116,7 @@ You should now be able to run PHP scripts:
 
 ## Switch between PHP versions
 
-The `/Volumes/Webdev/www/_apache/bin` directory of the HAMmP repository contains
+The `/Volumes/webdev/www/_apache/bin` directory of the HAMmP repository contains
 a helper script to switch between the different PHP versions.
 
 Run the command with the PHP version you want to enable:


### PR DESCRIPTION
Most commands/files use /Volumes/webdev, but there are 7 occurrences of /Volumes/Webdev, which causes incorrect behaviour when copy/pasted.