### PR TITLE
mysql location changed on M1

### DIFF
--- a/documentation/Installation/MariaDB.md
+++ b/documentation/Installation/MariaDB.md
@@ -32,7 +32,7 @@ The following is a single, multi-line command. Copy and paste the entire
 block at once:
 
 ```bash
-cat >> /usr/local/etc/my.cnf.d/mysqld.cnf <<'EOF'
+cat >> /opt/homebrew/etc/my.cnf.d/mysqld.cnf <<'EOF'
 
 [mysqld] 
 skip-external-locking
@@ -53,7 +53,7 @@ EOF
 ```
 
 ```bash
-cat >> /usr/local/etc/my.cnf.d/innodb.cnf <<'EOF'
+cat >> /opt/homebrew/etc/my.cnf.d/innodb.cnf <<'EOF'
 
 [innodb]
 innodb_file_per_table = 1


### PR DESCRIPTION
In case of installing MySQL with Homebrew in Mac M1 with MacOS Monterey 12.0.1 the location is /opt/homebrew/etc/my.cnf

See https://stackoverflow.com/questions/10757169/location-of-my-cnf-file-on-macos